### PR TITLE
logo: fixed kubic image dimensions

### DIFF
--- a/kubic-velum-branding/app/assets/images/logo.svg
+++ b/kubic-velum-branding/app/assets/images/logo.svg
@@ -9,12 +9,12 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="98.60006mm"
-   height="13.207999mm"
-   viewBox="0 0 98.60006 13.207999"
+   width="301.89487"
+   height="80"
+   viewBox="0 0 79.876349 21.166666"
    version="1.1"
    id="svg8"
-   inkscape:version="0.48.5 r10040"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
    sodipodi:docname="opensusekubictext.svg">
   <defs
      id="defs2" />
@@ -25,9 +25,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="0.7"
-     inkscape:cx="308.57412"
-     inkscape:cy="-358.52346"
+     inkscape:zoom="2.8"
+     inkscape:cx="138.92054"
+     inkscape:cy="-35.517458"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
      showgrid="false"
@@ -35,11 +35,12 @@
      fit-margin-left="0"
      fit-margin-right="0"
      fit-margin-bottom="0"
-     inkscape:window-width="2560"
-     inkscape:window-height="1359"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
      inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1" />
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     units="px" />
   <metadata
      id="metadata5">
     <rdf:RDF>
@@ -48,7 +49,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -56,20 +57,20 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(-3.3796101,-0.34815763)">
+     transform="translate(-12.741467,12.843018)">
     <text
        xml:space="preserve"
-       style="font-size:8.57431221px;font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;line-height:6.61458302px;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Source Sans Pro;-inkscape-font-specification:Source Sans Pro Light"
-       x="9.4125671"
-       y="10.182184"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;line-height:0%;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Light';letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;"
+       x="12.148048"
+       y="0.61004442"
        id="text5057"
        transform="scale(0.99991631,1.0000837)"><tspan
          sodipodi:role="line"
          id="tspan5055"
-         x="9.4125671"
-         y="10.182184"
-         style="font-size:11.43243027px;fill:#ffffff">openSUSE<tspan
-   style="font-size:4.57296753px;fill:#ffffff"
+         x="12.148048"
+         y="0.61004442"
+         style="font-size:11.43243027px;line-height:6.61458302;fill:#ffffff;">openSUSE<tspan
+   style="font-size:4.57296753px;fill:#ffffff;"
    id="tspan5067">©</tspan> Kubic</tspan></text>
   </g>
 </svg>


### PR DESCRIPTION
The previous image dimensions was causing the logo to be displayed
with wrong proportions in Velum. Now it behaves as expected similar to
CaaS Platform.

Signed-off-by: Vítor Avelino <vavelino@suse.com>

![screenshot-20180628065256-289x144](https://user-images.githubusercontent.com/188554/42027613-8770454a-7aa0-11e8-909f-4f9e7a9c3eba.png)
![screenshot-20180628065323-297x320](https://user-images.githubusercontent.com/188554/42027614-8794dc0c-7aa0-11e8-942b-d97899cf4579.png)
